### PR TITLE
Add basic Vitest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "deploy": "vite build && gh-pages -d dist",
     "lint": "eslint . --ext .vue,.js,.ts",
-    "lint:fix": "eslint . --ext .vue,.js,.ts --fix"
+    "lint:fix": "eslint . --ext .vue,.js,.ts --fix",
+    "test": "vitest"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^41.2.1",
@@ -41,6 +42,7 @@
     "gh-pages": "^6.1.1",
     "sass": "^1.69.7",
     "vite": "^5.0.10",
-    "vite-plugin-eslint": "^1.8.1"
+    "vite-plugin-eslint": "^1.8.1",
+    "vitest": "^1.0.0"
   }
 }

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { currency, date } from '../src/methods/filters';
+
+describe('filters', () => {
+  it('formats currency correctly', () => {
+    expect(currency(12345)).toBe('12,345');
+  });
+
+  it('converts timestamps to localized dates', () => {
+    const ts = 1640995200; // 2022-01-01 UTC
+    expect(date(ts)).toBe(new Date(ts * 1000).toLocaleDateString());
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add `vitest` as a dev dependency and expose a `test` script
- create `vitest.config.js` configuring node environment
- add an example test for `currency` and `date` filters

## Testing
- `npm install --save-dev vitest` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852469d7588832595abf4ac77b62d57