### PR TITLE
Standardize API environment variable names

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -190,8 +190,8 @@ Vue.js 電商購物網站開發，包含產品展示、購物車管理、結帳�
    
    // ✅ 實際 API 調用
    async getOrder(orderId) {
-     const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
-     const response = await axios.get(`${VITE_APP_URL}/api/${VITE_APP_PATH}/order/${orderId}`);
+     const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
+     const response = await axios.get(`${VITE_API_URL}/api/${VITE_API_PATH}/order/${orderId}`);
      this.order = response.data.order;
    }
    ```

--- a/src/components/ArticleModal.vue
+++ b/src/components/ArticleModal.vue
@@ -177,7 +177,7 @@ import { mapActions } from 'pinia';
 import useToastMessageStore from '@/stores/toastMessage';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 export default {
   props: {
     article: Object,
@@ -204,7 +204,7 @@ export default {
       const upLoadFile = this.$refs.fileInput.files[0];
       const formData = new FormData();
       formData.append('file-to-upload', upLoadFile);
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/upload`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/upload`;
       this.axios.post(url, formData)
         .then((res) => {
           this.tempArticle.image = res.data.imageUrl;

--- a/src/components/DeleteModal.vue
+++ b/src/components/DeleteModal.vue
@@ -47,7 +47,7 @@ import { mapActions } from 'pinia';
 import useToastMessageStore from '@/stores/toastMessage';
 import { Modal } from 'bootstrap';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 export default {
   data() {
     return {
@@ -71,7 +71,7 @@ export default {
     ...mapActions(useToastMessageStore, ['addMessage']),
     deleteProduct() {
       axios
-        .delete(`${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/product/${this.tempProduct.id}`)
+        .delete(`${VITE_API_URL}/api/${VITE_API_PATH}/admin/product/${this.tempProduct.id}`)
         .then((res) => {
           // console.log(res.data);
           this.addMessage({

--- a/src/components/ProductModal.vue
+++ b/src/components/ProductModal.vue
@@ -336,7 +336,7 @@ import useToastMessageStore from '@/stores/toastMessage';
 
 import modalMixin from '@/mixins/modalMixin';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 export default {
   data() {
     return {
@@ -415,7 +415,7 @@ export default {
       const upLoadFile = this.$refs.fileInput.files[0];
       const formData = new FormData();
       formData.append('file-to-upload', upLoadFile);
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/upload`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/upload`;
       this.status.fileUploading = true;
       axios.post(url, formData, {
         headers: {

--- a/src/stores/cartStore.js
+++ b/src/stores/cartStore.js
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia';
 import axios from 'axios';
 import useToastMessageStore from '@/stores/toastMessage';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default defineStore('cart', {
   state: () => ({
@@ -15,7 +15,7 @@ export default defineStore('cart', {
     getCart() {
       const toastStore = useToastMessageStore();
       axios
-        .get(`${VITE_APP_URL}/api/${VITE_APP_PATH}/cart`)
+        .get(`${VITE_API_URL}/api/${VITE_API_PATH}/cart`)
         .then((res) => {
           const { carts, total, final_total: apiFinalTotal } = res.data.data;
 
@@ -51,7 +51,7 @@ export default defineStore('cart', {
         qty,
       };
       axios
-        .post(`${VITE_APP_URL}/api/${VITE_APP_PATH}/cart`, { data: cart })
+        .post(`${VITE_API_URL}/api/${VITE_API_PATH}/cart`, { data: cart })
         .then((res) => {
           toastStore.addMessage({
             title: '成功',
@@ -72,7 +72,7 @@ export default defineStore('cart', {
       const toastStore = useToastMessageStore();
       try {
         const res = await axios.post(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/coupon`,
+          `${VITE_API_URL}/api/${VITE_API_PATH}/coupon`,
           {
             data: { code },
           }
@@ -104,7 +104,7 @@ export default defineStore('cart', {
       // 返回 Promise 以便組件處理加載狀態
       try {
         const res = await axios.put(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/cart/${item.id}`,
+          `${VITE_API_URL}/api/${VITE_API_PATH}/cart/${item.id}`,
           { data }
         );
         toastStore.addMessage({
@@ -129,7 +129,7 @@ export default defineStore('cart', {
       // 返回 Promise
       try {
         const res = await axios.delete(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/cart/${id}`
+          `${VITE_API_URL}/api/${VITE_API_PATH}/cart/${id}`
         );
         toastStore.addMessage({
           title: '成功',
@@ -153,7 +153,7 @@ export default defineStore('cart', {
       // 返回 Promise
       try {
         const res = await axios.delete(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/carts`
+          `${VITE_API_URL}/api/${VITE_API_PATH}/carts`
         );
         toastStore.addMessage({
           title: '成功',
@@ -176,7 +176,7 @@ export default defineStore('cart', {
       const toastStore = useToastMessageStore();
       try {
         const res = await axios.post(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/order`,
+          `${VITE_API_URL}/api/${VITE_API_PATH}/order`,
           { data: orderData } // API 期望的格式 { data: { user: {}, message: ''} }
         );
         toastStore.addMessage({
@@ -200,7 +200,7 @@ export default defineStore('cart', {
       const toastStore = useToastMessageStore();
       try {
         const res = await axios.post(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/pay/${orderId}`
+          `${VITE_API_URL}/api/${VITE_API_PATH}/pay/${orderId}`
         );
 
         toastStore.addMessage({

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -97,7 +97,7 @@ import { mapActions } from 'pinia';
 import useToastMessageStore from '@/stores/toastMessage';
 import ToastMessages from '@/components/ToastMessages.vue';
 
-const { VITE_APP_URL } = import.meta.env;
+const { VITE_API_URL } = import.meta.env;
 
 export default {
   data() {
@@ -123,7 +123,7 @@ export default {
           username: this.user.username, // 實際使用 tomgx09@gmail.com
           password: this.user.password,
         };
-        const res = await axios.post(`${VITE_APP_URL}/admin/signin`, loginData);
+        const res = await axios.post(`${VITE_API_URL}/admin/signin`, loginData);
         const { token, expired } = res.data;
         document.cookie = `hexToken=${token}; expires=${new Date(expired)};`;
         this.addMessage({

--- a/src/views/dashboard/ArticleListView.vue
+++ b/src/views/dashboard/ArticleListView.vue
@@ -223,7 +223,7 @@ import ArticleModal from '@/components/ArticleModal.vue';
 import DelModal from '@/components/DelModal.vue';
 import PageHeader from '@/components/PageHeader.vue';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   components: {
@@ -278,7 +278,7 @@ export default {
     getArticles(page = 1) {
       this.currentPage = page;
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/articles?page=${page}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/articles?page=${page}`;
       this.axios.get(url).then((res) => {
         this.articles = res.data.articles;
         this.isLoading = false;
@@ -299,7 +299,7 @@ export default {
     },
     getArticle(id) {
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/article/${id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/article/${id}`;
       this.axios.get(url).then((res) => {
         this.isLoading = false;
         this.openModal(false, res.data.article);
@@ -331,11 +331,11 @@ export default {
     updateArticle(item) {
       this.isLoading = true;
       this.tempArticle = { ...item };
-      let url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/article`;
+      let url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/article`;
       let httpMethod = 'post';
       let status = '新增貼文';
       if (!this.isNew) {
-        url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/article/${this.tempArticle.id}`;
+        url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/article/${this.tempArticle.id}`;
         httpMethod = 'put';
         status = '更新貼文';
       }
@@ -365,7 +365,7 @@ export default {
     },
     delArticle() {
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/article/${this.tempArticle.id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/article/${this.tempArticle.id}`;
       this.axios.delete(url).then((res) => {
         this.isLoading = false;
         this.addMessage({

--- a/src/views/dashboard/CouponView.vue
+++ b/src/views/dashboard/CouponView.vue
@@ -250,7 +250,7 @@ import PageHeader from '@/components/PageHeader.vue';
 import CouponModal from '@/components/CouponModal.vue';
 import DelModal from '@/components/DelModal.vue';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   components: {
@@ -332,7 +332,7 @@ export default {
     ...mapActions(useToastMessageStore, ['addMessage']),
     getCoupons() {
       this.isLoading = true;
-      this.axios.get(`${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/coupons`)
+      this.axios.get(`${VITE_API_URL}/api/${VITE_API_PATH}/admin/coupons`)
         .then((res) => {
           this.coupons = res.data.coupons;
           this.isLoading = false;
@@ -372,7 +372,7 @@ export default {
     },
     updateCouponStatus(item) {
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/coupon/${item.id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/coupon/${item.id}`;
       const data = {
         is_enabled: item.is_enabled,
       };
@@ -397,12 +397,12 @@ export default {
     },
     updateCoupon(tempCoupon) {
       this.isLoading = true;
-      let url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/coupon`;
+      let url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/coupon`;
       let httpMethods = 'post';
       let data = { ...tempCoupon };
 
       if (!this.isNew) {
-        url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/coupon/${tempCoupon.id}`;
+        url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/coupon/${tempCoupon.id}`;
         httpMethods = 'put';
         data = this.tempCoupon;
       }
@@ -428,7 +428,7 @@ export default {
     },
     deleteCoupon() {
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/coupon/${this.tempCoupon.id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/coupon/${this.tempCoupon.id}`;
       this.axios.delete(url)
         .then((res) => {
           this.isLoading = false;

--- a/src/views/dashboard/DashboardView.vue
+++ b/src/views/dashboard/DashboardView.vue
@@ -84,7 +84,7 @@ import { mapActions } from 'pinia';
 import useToastMessageStore from '@/stores/toastMessage';
 import ToastMessages from '@/components/ToastMessages.vue';
 
-const { VITE_APP_URL } = import.meta.env;
+const { VITE_API_URL } = import.meta.env;
 
 export default {
   data() {
@@ -166,7 +166,7 @@ export default {
     },
     checkLogin() {
       axios
-        .post(`${VITE_APP_URL}/api/user/check`)
+        .post(`${VITE_API_URL}/api/user/check`)
         .then((res) => {
           console.log(res.data.success);
           this.addMessage(
@@ -185,7 +185,7 @@ export default {
     },
     logout() {
       axios
-        .post(`${VITE_APP_URL}/logout`)
+        .post(`${VITE_API_URL}/logout`)
         .then(() => {
           this.$router.push('/login');
         })

--- a/src/views/dashboard/OrderView.vue
+++ b/src/views/dashboard/OrderView.vue
@@ -248,7 +248,7 @@ import PageHeader from '@/components/PageHeader.vue';
 import OrderModal from '@/components/OrderModal.vue';
 import DelModal from '@/components/DelModal.vue';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   data() {
@@ -350,7 +350,7 @@ export default {
     },
     getOrders(currentPage = 1) {
       this.currentPage = currentPage;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/orders?page=${currentPage}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/orders?page=${currentPage}`;
       this.axios.get(url).then((response) => {
         this.orders = response.data.orders;
       }).catch((error) => {
@@ -379,7 +379,7 @@ export default {
     },
     updatePaid(item) {
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/order/${item.id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/order/${item.id}`;
       const paid = {
         is_paid: item.is_paid,
       };
@@ -403,7 +403,7 @@ export default {
     },
     deleteOrder() {
       this.isLoading = true;
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/order/${this.tempOrder.id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/order/${this.tempOrder.id}`;
       this.axios.delete(url).then((response) => {
         this.$refs.delModal.closeModal();
         this.getOrders(this.currentPage);

--- a/src/views/dashboard/ProductsView.vue
+++ b/src/views/dashboard/ProductsView.vue
@@ -128,7 +128,7 @@ import ProductModal from '../../components/ProductModal.vue';
 import DeleteModal from '../../components/DeleteModal.vue';
 import PaginationComponent from '../../components/PaginationComponent.vue';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   data() {
@@ -151,7 +151,7 @@ export default {
     getProducts(page = 1) {
       this.isLoading = true;
       axios
-        .get(`${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/products?page=${page}`)
+        .get(`${VITE_API_URL}/api/${VITE_API_PATH}/admin/products?page=${page}`)
         .then((res) => {
           const { products, pagination } = res.data;
           this.products = products;
@@ -185,11 +185,11 @@ export default {
     },
     updateProduct(item) {
       this.isLoading = true;
-      let url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/product/${this.tempProduct.id}`;
+      let url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/product/${this.tempProduct.id}`;
       let http = 'put';
 
       if (this.isNew) {
-        url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/admin/product`;
+        url = `${VITE_API_URL}/api/${VITE_API_PATH}/admin/product`;
         http = 'post';
       }
       axios[http](url, { data: item })

--- a/src/views/front/ArticleView.vue
+++ b/src/views/front/ArticleView.vue
@@ -224,7 +224,7 @@
 import { mapActions } from 'pinia';
 import useToastMessageStore from '@/stores/toastMessage';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   data() {
@@ -237,7 +237,7 @@ export default {
   methods: {
     ...mapActions(useToastMessageStore, ['addMessage']),
     getArticle() {
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/article/${this.id}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/article/${this.id}`;
       this.isLoading = true;
       this.axios.get(url)
         .then((res) => {

--- a/src/views/front/ArticlesView.vue
+++ b/src/views/front/ArticlesView.vue
@@ -128,7 +128,7 @@ import { mapActions } from 'pinia';
 import useToastMessageStore from '@/stores/toastMessage';
 import HeroSection from '@/components/HeroSection.vue';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   components: {
@@ -144,7 +144,7 @@ export default {
   methods: {
     ...mapActions(useToastMessageStore, ['addMessage']),
     getArticles(page = 1) {
-      const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/articles?page=${page}`;
+      const url = `${VITE_API_URL}/api/${VITE_API_PATH}/articles?page=${page}`;
       this.isLoading = true;
       this.axios(url)
         .then((res) => {

--- a/src/views/front/OrderDetailView.vue
+++ b/src/views/front/OrderDetailView.vue
@@ -309,11 +309,11 @@ export default {
         return;
       }
 
-      const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+      const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
       this.isLoading = true;
 
       try {
-        const url = `${VITE_APP_URL}/api/${VITE_APP_PATH}/order/${orderId}`;
+        const url = `${VITE_API_URL}/api/${VITE_API_PATH}/order/${orderId}`;
         const response = await axios.get(url);
         this.order = response.data.order;
       } catch (error) {

--- a/src/views/front/OrdersListView.vue
+++ b/src/views/front/OrdersListView.vue
@@ -326,9 +326,9 @@ export default {
         this.isLoading = true;
         this.error = null;
 
-        const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+        const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
         const response = await axios.get(
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/orders?page=${page}`,
+          `${VITE_API_URL}/api/${VITE_API_PATH}/orders?page=${page}`,
         );
 
         if (response.data.success) {

--- a/src/views/front/ProductView.vue
+++ b/src/views/front/ProductView.vue
@@ -354,7 +354,7 @@ import 'swiper/css/pagination';
 import useCartStore from '@/stores/cartStore';
 import useToastMessageStore from '@/stores/toastMessage';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   components: {
@@ -434,7 +434,7 @@ export default {
       this.isProductLoading = true; // 開始載入
       this.imageLoadedCount = 0; // 重置圖片載入計數
 
-      fetch(`${VITE_APP_URL}/api/${VITE_APP_PATH}/product/${id}`)
+      fetch(`${VITE_API_URL}/api/${VITE_API_PATH}/product/${id}`)
         .then((res) => res.json())
         .then((data) => {
           this.product = data.product;
@@ -472,7 +472,7 @@ export default {
     getRelatedProducts() {
       if (!this.product.category) return;
 
-      fetch(`${VITE_APP_URL}/api/${VITE_APP_PATH}/products?category=${this.product.category}`)
+      fetch(`${VITE_API_URL}/api/${VITE_API_PATH}/products?category=${this.product.category}`)
         .then((res) => res.json())
         .then((data) => {
           // 過濾掉當前產品，只顯示其他同分類產品，最多顯示4個

--- a/src/views/front/ProductsView.vue
+++ b/src/views/front/ProductsView.vue
@@ -217,7 +217,7 @@ import { mapActions } from 'pinia';
 import PaginationComponent from '@/components/PaginationComponent.vue';
 import HeroSection from '@/components/HeroSection.vue';
 
-const { VITE_APP_URL, VITE_APP_PATH } = import.meta.env;
+const { VITE_API_URL, VITE_API_PATH } = import.meta.env;
 
 export default {
   components: {
@@ -257,7 +257,7 @@ export default {
     // 獲取所有分類
     getCategories() {
       axios
-        .get(`${VITE_APP_URL}/api/${VITE_APP_PATH}/products/all`)
+        .get(`${VITE_API_URL}/api/${VITE_API_PATH}/products/all`)
         .then((res) => {
           // 從所有產品中提取唯一的分類
           const uniqueCategories = [...new Set(res.data.products.map((product) => product.category))];
@@ -282,7 +282,7 @@ export default {
       axios
         .get(
           // eslint-disable-next-line comma-dangle
-          `${VITE_APP_URL}/api/${VITE_APP_PATH}/products?category=${category}&page=${page}`
+          `${VITE_API_URL}/api/${VITE_API_PATH}/products?category=${category}&page=${page}`
         )
         .then((res) => {
           this.products = res.data.products;


### PR DESCRIPTION
## Summary
- rename `VITE_APP_URL` and `VITE_APP_PATH` to `VITE_API_URL` and `VITE_API_PATH`
- update imports across source code and docs

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68524307626c83259389c8b4e8c13f80